### PR TITLE
Enable zlib compression

### DIFF
--- a/Build.act
+++ b/Build.act
@@ -3,11 +3,20 @@ fingerprint = 0xee8dcc44255e0a2e
 zig_dependencies = {
     "libssh": (
         path="deps/libssh",
-        options={"WITH_SERVER": "true", "acton_sysdeps": "actonbase_dep.path(\"../deps\").getPath(b)"},
+        options={
+            "WITH_SERVER": "true",
+            "acton_sysdeps": "actonbase_dep.path(\"../deps\").getPath(b)",
+            "acton_zlib_src": "actdep_acton_zlib.builder.dependency(\"acton_zig_zlib\", .{{}}).builder.dependency(\"zlib_upstream\", .{{}}).path(\".\").getPath(b)"
+        },
         artifacts=["ssh"]
     )
 }
 dependencies = {
+    "acton_zlib": (
+        repo_url="https://github.com/actonlang/acton-zlib.git",
+        url="https://github.com/actonlang/acton-zlib/archive/aad0c3fd2dab64b3c4728ac96cd9362c793fb932.zip",
+        hash="N-V-__8AAF8XAAAaNtxndtX1uIB1vN-tsG6h7ZIPoDoCQ226"
+    ),
     "acton_pipe": (
         repo_url="https://github.com/actonlang/pipe.git",
         url="https://github.com/actonlang/pipe/archive/21a42ed57263c1d5c10ea733b03ae731b9efabd1.zip",

--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ Acton server, to OpenSSH `sshd`, or be driven by the OpenSSH `ssh` client.
 - **Server**: password and public-key auth callbacks, `exec`/`subsystem`
   dispatch, per-channel data streaming, ephemeral-port binding, in-memory or
   file-based host keys, and admission limits (max sessions / channels).
+- **Compression**: `zlib@openssh.com` and `zlib` are compiled in and offered
+  during key exchange, so a peer that asks for compression gets it. libssh
+  proposes `none` first, so it is never used unless the peer prefers it.
 - **Hardened**: bounded teardown (a stalled peer can't wedge a close),
   per-channel write-buffer limits, an accept loop that survives
   per-connection failures, and no use-after-free under load (validated with
@@ -30,6 +33,14 @@ This package builds an unmodified upstream libssh release with the Zig wrapper
 in [`deps/libssh`](deps/libssh). libuv supplies readiness notifications and the
 binding advances libssh through its public nonblocking `ssh_event` API. The
 dependency is declared in [`Build.act`](Build.act).
+
+libssh's compression methods use zlib from the
+[acton-zlib](https://github.com/actonlang/acton-zlib) package: the wrapper
+compiles against the headers of the exact zlib source acton-zlib pins, and the
+zlib objects reach the final executable link through the package dependency —
+the same headers-here/objects-there split used for mbedtls. The zlib version is
+pinned in one place (acton-zlib), and an executable that also uses the Acton
+`zlib` package links a single copy.
 
 libssh and its crypto backend (mbedtls) run on the C library heap with their
 own ownership; only libuv and Acton objects live on the GC heap. See the

--- a/deps/libssh/build.zig
+++ b/deps/libssh/build.zig
@@ -11,9 +11,18 @@
 // here. The mbedtls objects are provided by Acton's base library at the final
 // executable link; linking them here too would only duplicate symbols. Using
 // the toolchain's own headers guarantees the ABI matches the mbedtls base links.
+//
+// zlib, which libssh needs for the zlib@openssh.com / zlib compression methods,
+// follows the same split with the acton-zlib package as the supplier: this
+// project depends on acton_zlib (see Build.act), whose ActonProject archive
+// carries the zlib objects to the final executable link.
+// We compile against the headers of the exact zlib source acton-zlib pins,
+// reached through its wrapper's own dependency and injected as the
+// -Dacton_zlib_src build option, so the zlib version is pinned in one place.
 
 const builtin = @import("builtin");
 const std = @import("std");
+
 
 pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{});
@@ -26,6 +35,10 @@ pub fn build(b: *std.Build) void {
     // headers libssh compiles against (must match the mbedtls that base links).
     // Empty only for a standalone `zig build` that does not use the crypto backend.
     const acton_sysdeps = b.option([]const u8, "acton_sysdeps", "Absolute path to the Acton toolchain deps dir (<dist>/deps)") orelse "";
+    // Absolute path to the zlib source tree pinned by the acton-zlib package,
+    // injected by Build.act. Headers only — the objects come from acton_zlib's
+    // ActonProject at the final link (see top-of-file note).
+    const acton_zlib_src = b.option([]const u8, "acton_zlib_src", "Absolute path to the zlib source tree pinned by acton-zlib") orelse "";
 
     const upstream = b.dependency("libssh_upstream", .{});
 
@@ -147,7 +160,7 @@ pub fn build(b: *std.Build) void {
 
             .HAVE_GCC_BOUNDED_ATTRIBUTE = false,
             .WITH_GSSAPI = false,
-            .WITH_ZLIB = false,
+            .WITH_ZLIB = true,
             .WITH_FIDO2 = false,
             .WITH_SFTP = false,
             .WITH_SERVER = with_server,
@@ -297,6 +310,9 @@ pub fn build(b: *std.Build) void {
     // toolchain's <dist>/deps; mbedtls headers live under mbedtls/include.
     if (acton_sysdeps.len > 0) {
         lib.root_module.addIncludePath(.{ .cwd_relative = b.pathJoin(&.{ acton_sysdeps, "mbedtls", "include" }) });
+    }
+    if (acton_zlib_src.len > 0) {
+        lib.root_module.addIncludePath(.{ .cwd_relative = acton_zlib_src });
     }
     lib.root_module.link_libc = true;
 

--- a/interop/run_interop.sh
+++ b/interop/run_interop.sh
@@ -104,6 +104,19 @@ else
         sed -n 1,10p "$TMP/sshA2.err"
     fi
 
+    # compression: the client asks for it, so zlib@openssh.com must be
+    # negotiated in both directions and the channel must still round-trip.
+    out=$(ssh_to_acton "$TMP/askpass-good" -vv -o Compression=yes \
+              interop@127.0.0.1 ping 2>"$TMP/sshA6.err")
+    rc=$?
+    negotiated=$(grep -c "compression: zlib@openssh.com" "$TMP/sshA6.err")
+    if [ $rc -eq 0 ] && [ "$out" = "pong" ] && [ "$negotiated" -eq 2 ]; then
+        ok "compression negotiated zlib@openssh.com both ways, exec still works"
+    else
+        bad "compression (rc=$rc out=$out zlib_directions=$negotiated)"
+        grep -E "compression: " "$TMP/sshA6.err" | sed -n 1,4p
+    fi
+
     # wrong password: must fail
     out=$(ssh_to_acton "$TMP/askpass-bad" interop@127.0.0.1 ping 2>"$TMP/sshA3.err")
     rc=$?

--- a/src/test_ssh.act
+++ b/src/test_ssh.act
@@ -13,7 +13,7 @@ import testing
 
 
 def _test_version():
-    testing.assertEqual("0.12.2/mbedtls", ssh.version())
+    testing.assertEqual("0.12.2/mbedtls/zlib", ssh.version())
 
 
 TEST_USER = "testuser"


### PR DESCRIPTION
libssh was built with `WITH_ZLIB` off, so its kex proposal offered only `none` and `gzip.c` compiled to an empty translation unit.

Turn it on with zlib sourced from the [acton-zlib](https://github.com/actonlang/acton-zlib) package, split the same way as mbedtls: the libssh wrapper compiles against headers only, and the objects arrive at the final executable link through the package dependency, via its `ActonProject` archive. The headers are taken from the exact zlib source acton-zlib pins, reached through its wrapper's own zig dependency and injected as the `-Dacton_zlib_src` build option — so the zlib version is pinned in one place and follows acton-zlib's upgrades. An executable that also uses the Acton zlib package links a single copy.

libssh now reports `0.12.2/mbedtls/zlib` and proposes `none,zlib@openssh.com` (the libssh default): compression is offered but not preferred, so a peer only gets it by asking — negotiation follows the client's preference order per RFC 4253. Covered with a new interop case that verifies an OpenSSH client with `Compression=yes` negotiates `zlib@openssh.com` in both directions against the Acton server.