### PR TITLE
fail the session when a packet handler records a fatal error

### DIFF
--- a/src/lib.ext.c
+++ b/src/lib.ext.c
@@ -493,10 +493,13 @@ static void ssh_configure_libssh_logging(void) {
  * this poll reads its own revents from libssh's event mask, so callers only
  * use it to decide whether a poll is worth making at all. SSH_AGAIN means
  * readiness changed between the two polls, which is not an error. */
-static int session_event_poll(ssh_event event) {
-    if (event == NULL)
+static int session_event_poll(ssh_session session, ssh_event event) {
+    if (session == NULL || event == NULL)
         return -1;
+    int pre_fatal = ssh_get_error_code(session) == SSH_FATAL;
     if (ssh_event_dopoll(event, 0) == SSH_ERROR)
+        return -1;
+    if (!pre_fatal && ssh_get_error_code(session) == SSH_FATAL)
         return -1;
     return 0;
 }
@@ -2064,7 +2067,7 @@ static void client_poll_cb(uv_poll_t *handle, int status, int events) {
         ssh_set_fd_towrite(c->session);
         ready = 1;
     }
-    if (ready && session_event_poll(c->event) != 0) {
+    if (ready && session_event_poll(c->session, c->event) != 0) {
         char errmsg[256] = {0};
         session_failure_reason(c->session, errmsg, sizeof(errmsg));
         client_fail(c, errmsg);
@@ -2124,7 +2127,7 @@ static void client_pump_io(ssh_client_ctx *c) {
         int has_data = fd_has_data(c->fd);
         if (has_data) {
             ssh_set_fd_toread(c->session);
-            if (session_event_poll(c->event) != 0) {
+            if (session_event_poll(c->session, c->event) != 0) {
                 char errmsg[256] = {0};
                 session_failure_reason(c->session, errmsg, sizeof(errmsg));
                 client_fail(c, errmsg);
@@ -3456,7 +3459,7 @@ static void session_pump_io(ssh_server_session_ctx *s) {
         int has_data = fd_has_data(s->fd);
         if (has_data) {
             ssh_set_fd_toread(s->session);
-            if (session_event_poll(s->event) != 0) {
+            if (session_event_poll(s->session, s->event) != 0) {
                 char errmsg[256] = {0};
                 session_failure_reason(s->session, errmsg, sizeof(errmsg));
                 session_fail(s, errmsg);
@@ -3793,7 +3796,7 @@ static void session_poll_cb(uv_poll_t *handle, int status, int events) {
         ssh_set_fd_towrite(s->session);
         ready = 1;
     }
-    if (ready && session_event_poll(s->event) != 0) {
+    if (ready && session_event_poll(s->session, s->event) != 0) {
         char errmsg[256] = {0};
         session_failure_reason(s->session, errmsg, sizeof(errmsg));
         session_fail(s, errmsg);

--- a/src/test_ssh_hello_storm.act
+++ b/src/test_ssh_hello_storm.act
@@ -1,0 +1,309 @@
+"""Reproducer for first-data corruption on newly opened channels under load.
+
+Field report: with ~250 concurrent NETCONF subsystem sessions, a small
+fraction of sessions receive the server <hello> with its leading bytes
+missing (stream starts mid-capability), which then fails XML parsing.
+
+This test mimics that workload in-process: one ssh.Server that, like a
+NETCONF server, writes a multi-kilobyte hello in many small chunks the
+moment the subsystem request is accepted, and ROUNDS x NUM concurrent
+clients that each open a session channel, request the subsystem and then
+verify on EVERY on_stdout delivery that the bytes received so far are an
+exact prefix of the expected hello. Any lost, reordered or duplicated
+leading bytes fail the test immediately with the received head attached.
+
+Odd rounds defer the server-side hello write through `after 0` so the
+write is issued from a later actor turn, varying the interleaving between
+the subsystem accept, the hello write and the client's own first write.
+
+The defaults are sized to fit the plain `acton test` budget (a test is
+killed after max(--max-time, 2s) + 1s, and every session costs a full key
+exchange). For a real soak, raise the concurrency with
+ACTON_SSH_STORM_NUM -- but only as far as the run still completes (~64 on one
+host; see the scope note below) -- and give the harness room:
+
+    ACTON_SSH_STORM_NUM=32 acton test --module test_ssh_hello_storm \\
+        --max-time 120000 --min-iter 1 --max-iter 1
+    ACTON_SSH_STORM_NUM=32 acton test stress \\
+        --module test_ssh_hello_storm --stress-workers 4 \\
+        --max-time 240000 --min-iter 1 --max-iter 1
+
+`acton test stress` adds scheduling chaos on top.
+
+Two things this test does NOT do, so nobody spends another afternoon on it:
+
+- **It cannot trigger the "Window exceeded" discard** that the `pre_fatal`
+  guard in `session_event_poll` catches -- and neither can anything else on a
+  stock build. That branch needs a DATA packet larger than the
+  channel's local window, but `packet.c:1170` caps any transport packet at
+  `MAX_PACKET_LEN` = 262,144 B, far below the fresh 2,097,152 B window
+  (`WINDOW_DEFAULT` = `64 * CHANNEL_MAX_PACKET`, `src/channels.c:67`). It is
+  reachable only by a receiver whose window has diverged *below* the incoming
+  packet size. ANALYSIS-first-data-corruption.md, section *Forcing the
+  discard*, gives the recipe for producing that divergence in a local libssh
+  build, and `src/test_ssh_hello_storm.sh` automates it; with one
+  server hello chunk dropped, the assertion below fires with exactly the field
+  symptom. On the stock build this file is a guard for the
+  reported *symptom*, not a reproducer of that *mechanism*.
+- **It stops testing the data path entirely above ~64 sessions.** The first
+  failing client calls `finish_error`, which aborts the whole test, and past
+  ~128 concurrent handshakes on one host a client always loses the connect
+  race first (`SSH connect timeout` at `ssh.Client`'s 10 s default
+  `connect_timeout`, or `bad file descriptor` -- a `UV_EBADF` delivered to
+  `client_poll_cb` when libssh closes a session socket out from under a live
+  `uv_poll_t`). Neither says anything about data integrity. Raising
+  ACTON_SSH_STORM_NUM past what completes makes this test cover *less*, not
+  more; prefer `acton test stress` for scheduling chaos.
+
+The only output that confirms the reported bug is the prefix assertion:
+`corrupt hello (round R client C): received N bytes, head=...`. It has never
+fired in-process. To confirm the mechanism on an affected host, run against
+the real peer with `ACTON_SSH_LIBSSH_LOG=warn` (see
+ANALYSIS-first-data-corruption.md) and watch for
+`Data packet too big for our window(N vs M)`.
+"""
+
+import net
+import lib as ssh
+import testing
+
+
+TEST_USER = "netconf"
+TEST_PASS = "netconf-pass"
+
+
+actor HelloStormTester(t: testing.EnvT):
+    NUM = 4           # concurrent sessions per round (see ACTON_SSH_STORM_NUM)
+    ROUNDS = 2        # even round writes the hello inline, odd round defers it
+    CHUNK = 1024      # server-side write granularity for the hello
+
+    var num = NUM
+
+    var hello = b""
+    var client_hello = b'<hello xmlns="urn:ietf:params:xml:ns:netconf:base:1.0"><capabilities><capability>urn:ietf:params:netconf:base:1.1</capability></capabilities></hello>]]>]]>'
+
+    var done = False
+    var server: ?ssh.Server = None
+    var port: u16 = 0
+    var round_num = 0
+    var completed = 0                        # sessions with a fully verified hello, this round
+    var closed = 0                           # client close callbacks seen, this round
+    var total_ok = 0
+    var bufs: dict[int, bytes] = {}          # per-client accumulated stdout
+    var clients: dict[int, ssh.Client] = {}  # per-client handle, for teardown
+    var all_clients: list[ssh.Client] = []
+
+    def finish_error(msg: str):
+        if done:
+            return
+        done = True
+        for c in all_clients:
+            c.close()
+        s = server
+        if s is not None:
+            s.close()
+        t.error(Exception(msg))
+
+    def on_timeout():
+        finish_error("timeout: round " + str(round_num) + " of " + str(ROUNDS) +
+                     ", completed " + str(completed) + "/" + str(num) +
+                     " (total ok " + str(total_ok) + ")")
+
+    # --- server side
+    def on_listen(s: ssh.Server, err: ?str):
+        if err is not None:
+            finish_error("server listen error: " + err)
+            return
+        port = await async s.bound_port()
+        # Soak knob: ACTON_SSH_STORM_NUM raises the concurrency without a
+        # source edit (the default is sized to fit `acton test`'s budget).
+        override = await async t.env.getenv("ACTON_SSH_STORM_NUM")
+        if override is not None:
+            try:
+                num = int(override)
+            except ValueError:
+                pass
+        start_round()
+
+    def on_server_close(s: ssh.Server, reason: str):
+        if done:
+            return
+        if total_ok == num * ROUNDS:
+            done = True
+            t.success()
+        else:
+            finish_error("server closed early: " + reason + " (total ok " + str(total_ok) + ")")
+
+    def on_session(sess: ssh.ServerSession):
+        pass
+
+    def on_auth(sess: ssh.ServerSession, req: ssh.AuthRequest):
+        if req.method == "password" and req.user == TEST_USER and req.password == TEST_PASS:
+            sess.accept_auth()
+        else:
+            sess.reject_auth("invalid credentials")
+
+    def srv_on_data(ch: ssh.ServerChannel, data: ?bytes):
+        # Inbound client hello is load, not what we verify here.
+        pass
+
+    def srv_on_stderr(ch: ssh.ServerChannel, data: ?bytes):
+        pass
+
+    def srv_on_close(ch: ssh.ServerChannel, reason: str):
+        pass
+
+    def on_channel_open(sess: ssh.ServerSession):
+        sess.accept_channel(ssh.ServerChannel(sess, srv_on_data, srv_on_stderr, srv_on_close))
+
+    def send_hello(ch: ssh.ServerChannel):
+        # Write the hello like a real NETCONF server: immediately, and in
+        # many small chunks so it spans several SSH DATA packets.
+        offset = 0
+        while offset < len(hello):
+            end = offset + CHUNK
+            if end > len(hello):
+                end = len(hello)
+            ch.write(hello[offset:end])
+            offset = end
+
+    def on_subsystem(sess: ssh.ServerSession, ch: ssh.ServerChannel, name: str):
+        if name == "netconf":
+            ch.accept_request()
+            if round_num % 2 == 0:
+                send_hello(ch)
+            else:
+                # Defer to a later actor turn: varies the interleaving of
+                # the subsystem reply, the hello write and client traffic.
+                def deferred_hello():
+                    send_hello(ch)
+                after 0.0: deferred_hello()
+        else:
+            ch.reject_request("unsupported subsystem")
+
+    def on_exec(sess: ssh.ServerSession, ch: ssh.ServerChannel, cmd: str):
+        ch.reject_request("exec disabled")
+
+    # --- client side
+    def on_hostkey(c: ssh.Client, state: str, info: ssh.HostKeyInfo):
+        c.accept_hostkey()
+
+    def round_done():
+        if done:
+            return
+        round_num += 1
+        if round_num >= ROUNDS:
+            s = server
+            if s is not None:
+                s.close()
+        else:
+            start_round()
+
+    def start_round():
+        completed = 0
+        closed = 0
+        all_clients = []
+        for i in range(num):
+            start_one(i)
+
+    def start_one(i: int):
+        bufs[i] = b""
+
+        def ch_open(ch: ssh.Channel, err: ?str):
+            if done:
+                return
+            if err is not None:
+                finish_error("client " + str(i) + " channel open error: " + err)
+                return
+            ch.request_subsystem("netconf")
+            # Bidirectional first-data traffic, like a real NETCONF client.
+            ch.write(client_hello)
+
+        def ch_out(ch: ssh.Channel, data: ?bytes):
+            if done:
+                return
+            if data is not None:
+                nb = bufs[i] + data
+                # THE core assertion: everything received so far must be an
+                # exact prefix of the expected hello. Missing/reordered
+                # leading bytes fail here on the very first delivery.
+                if hello[0:len(nb)] != nb:
+                    finish_error("corrupt hello (round " + str(round_num) +
+                                 " client " + str(i) + "): received " + str(len(nb)) +
+                                 " bytes, head=" + str(nb[0:80]))
+                    return
+                bufs[i] = nb
+                if len(nb) == len(hello):
+                    total_ok += 1
+                    completed += 1
+                    ch.close()
+
+        def ch_err(ch: ssh.Channel, data: ?bytes):
+            pass
+
+        def ch_exit(ch: ssh.Channel, code: int, sig: ?str):
+            pass
+
+        def ch_close(ch: ssh.Channel, reason: str):
+            if done:
+                return
+            clients[i].close()
+
+        def on_connect(c: ssh.Client, err: ?str):
+            if done:
+                return
+            if err is not None:
+                finish_error("client " + str(i) + " connect error: " + err)
+                return
+            ssh.Channel(c, ch_open, ch_out, ch_err, ch_exit, ch_close)
+
+        def on_client_close(c: ssh.Client, reason: str):
+            if done:
+                return
+            closed += 1
+            if closed == num:
+                if completed != num:
+                    finish_error("round " + str(round_num) + ": only " + str(completed) +
+                                 "/" + str(num) + " sessions saw a complete hello")
+                    return
+                round_done()
+
+        c = ssh.Client(
+            net.TCPConnectCap(net.TCPCap(net.NetCap(t.env.cap))),
+            "127.0.0.1",
+            TEST_USER,
+            on_connect,
+            on_client_close,
+            on_hostkey,
+            password=TEST_PASS,
+            port=port,
+        )
+        clients[i] = c
+        all_clients.append(c)
+
+    # A realistic multi-kilobyte NETCONF hello: many capability URIs, so the
+    # transfer spans many SSH DATA packets and socket reads.
+    hello = b'<?xml version="1.0" encoding="UTF-8"?><hello xmlns="urn:ietf:params:xml:ns:netconf:base:1.0"><capabilities>'
+    for i in range(120):
+        hello += b'<capability>urn:example:params:xml:ns:yang:mod-' + str(i).encode() + \
+                 b'?module=mod-' + str(i).encode() + b'&amp;revision=2024-01-01</capability>'
+    hello += b'</capabilities><session-id>1</session-id></hello>]]>]]>'
+
+    server = ssh.Server(
+        net.TCPListenCap(net.TCPCap(net.NetCap(t.env.cap))),
+        "127.0.0.1",
+        u16(0),
+        on_listen,
+        on_server_close,
+        on_session,
+        on_auth,
+        on_channel_open,
+        on_exec,
+        on_subsystem,
+    )
+    after 60.0: on_timeout()
+
+
+def _test_hello_storm(t: testing.EnvT):
+    """Concurrent subsystem sessions: first channel data must never lose its head."""
+    HelloStormTester(t)

--- a/src/test_ssh_hello_storm.sh
+++ b/src/test_ssh_hello_storm.sh
@@ -1,0 +1,255 @@
+#!/usr/bin/env bash
+#
+# Reproduce the reported first-data corruption ("Window exceeded") in-process.
+#
+# Why this needs a patched libssh: channel_rcv_data discards a DATA packet when
+# len > channel->local_window (libssh 0.12.2 src/channels.c:670), but
+# packet.c caps any transport packet at MAX_PACKET_LEN = 262144 B, far below a
+# fresh WINDOW_DEFAULT = 2097152 B window. No compliant -- or even hostile --
+# sender can reach that branch. It is reachable only by a receiver whose window
+# has diverged BELOW the incoming packet size. This script builds a libssh that
+# fakes exactly that divergence for a chosen packet, so the discard is real and
+# the bytes are really lost.
+#
+# It then runs test_ssh_hello_storm twice -- against stock libssh, and against
+# the candidate RFC 4254 5.2 clamp patch (see LIBSSH-window-clamp.md) -- and
+# reports how often the corrupt stream reaches the application in each.
+#
+# It does NOT touch src/lib.ext.c. The pre_fatal guard that used to be A/B'd
+# here was never committed to a branch and is not in the tree; commit 21dd241
+# replaced session_apply_poll_events with session_event_poll and dropped it.
+# (ssh_event_dopoll does not compensate: ssh_poll_ctx_dopoll returns SSH_ERROR
+# only on an empty context, a failed poll(), or a socket callback returning -2
+# -- read error and EOF only -- so an SSH_FATAL recorded by channel_rcv_data
+# never surfaces.) If you restore the guard, run this before and after to
+# compare.
+#
+# Everything it touches is restored on exit, including on Ctrl-C.
+#
+# Usage:
+#   src/test_ssh_hello_storm.sh [repeats]     # default 12
+#
+# Runs from anywhere -- it resolves the repo root from its own location.
+#
+# Environment:
+#   LIBSSH_SRC   libssh source to build from. Default: the exact tarball this
+#                tree pins, unpacked from acton's package cache. Override only
+#                if the source matches deps/libssh/build.zig's file list -- an
+#                older checkout will be missing sources the wrapper compiles
+#                (e.g. src/hybrid_mlkem.c after the 0.12 upgrade) and the build
+#                dies with "file_hash FileNotFound".
+#   ACTON        acton binary                    (default: ../acton/bin/acton)
+#   ACTON_CACHE  acton cache root                (default: ~/.cache/acton)
+#   LIBSSH_REPRO_DROP_WINDOW
+#                fake window for the dropped 1024 B packet (default 0). 0 means
+#                nothing fits, so both variants lose the whole packet and only
+#                the error behaviour differs. Set e.g. 500 to see the clamp
+#                deliver the part that fits while stock libssh drops it all.
+
+set -uo pipefail
+
+REPEATS="${1:-12}"
+# This script lives in src/; everything it touches is relative to the repo root.
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LIBSSH_SRC="${LIBSSH_SRC:-}"
+ACTON="${ACTON:-/usr/bin/acton}"
+ACTON_CACHE="${ACTON_CACHE:-$HOME/.cache/acton}"
+
+LOCAL_LIBSSH="$REPO/deps/libssh/libssh-local"
+BACKUP="$(mktemp -d)"
+
+die() { echo "error: $*" >&2; exit 1; }
+say() { printf '\n\033[1m== %s\033[0m\n' "$*"; }
+
+restore() {
+    say "Restoring tree"
+    for f in deps/libssh/build.zig deps/libssh/build.zig.zon; do
+        [ -f "$BACKUP/$(basename "$f")" ] && cp "$BACKUP/$(basename "$f")" "$REPO/$f"
+    done
+    rm -rf "$LOCAL_LIBSSH" "$BACKUP"
+    "$ACTON" build >/dev/null 2>&1
+    git -C "$REPO" status --short -- deps
+}
+trap restore EXIT INT TERM
+
+[ -x "$ACTON" ] || die "acton not found at $ACTON (set ACTON=)"
+cd "$REPO"
+
+cp deps/libssh/build.zig deps/libssh/build.zig.zon "$BACKUP/"
+
+# ------------------------------------------------------- 0. which libssh source
+# Building the repro against a different libssh than deps/libssh/build.zig was
+# written for is the easiest way to get a silent false negative, so default to
+# the source this tree actually pins.
+if [ -z "$LIBSSH_SRC" ]; then
+    say "Resolving the pinned libssh source"
+    pinhash=$(sed -n 's/.*\.hash = "\([^"]*\)".*/\1/p' deps/libssh/build.zig.zon | head -1)
+    [ -n "$pinhash" ] || die "no .hash found in deps/libssh/build.zig.zon"
+    tarball="$ACTON_CACHE/zig-global-cache/p/$pinhash.tar.gz"
+    [ -f "$tarball" ] || die "pinned tarball not in the cache: $tarball
+  run '$ACTON build' once to fetch it, or set LIBSSH_SRC= to a matching source"
+    mkdir -p "$BACKUP/pinned"
+    tar xf "$tarball" -C "$BACKUP/pinned" || die "could not unpack $tarball"
+    found=$(find "$BACKUP/pinned" -maxdepth 2 -type d -name src -print -quit)
+    [ -n "$found" ] || die "no src/ directory inside $tarball"
+    LIBSSH_SRC="${found%/src}"
+    echo "  using $(basename "$tarball")"
+fi
+[ -d "$LIBSSH_SRC/src" ] || die "libssh source not found at $LIBSSH_SRC"
+
+# ---------------------------------------------------------------- 1. local copy
+# zig rejects absolute and escaping .path values, so the copy must live inside
+# the build root (deps/libssh/).
+say "Copying libssh from $LIBSSH_SRC"
+rm -rf "$LOCAL_LIBSSH"
+cp -a "$LIBSSH_SRC" "$LOCAL_LIBSSH" || die "copy failed"
+rm -rf "$LOCAL_LIBSSH/.git"
+
+# The wrapper's file list and the source have to agree, or zig fails with an
+# opaque "file_hash FileNotFound" that is easy to mistake for "no bug here".
+missing=$(python3 -c "
+import re, os
+srcs = re.findall(r'\"(src/[^\"]+[.]c)\"', open('deps/libssh/build.zig').read())
+print(' '.join(x for x in srcs if not os.path.exists(os.path.join('deps/libssh/libssh-local', x))))
+")
+[ -z "$missing" ] || die "this libssh source is missing files deps/libssh/build.zig compiles:
+  $missing
+  It does not match the pin. Unset LIBSSH_SRC to use the pinned tarball."
+
+# ---------------------------------------------------------------- 2. the hook
+say "Patching channels.c with the window-divergence hook"
+python3 - "$LOCAL_LIBSSH/src/channels.c" <<'PY'
+import sys
+p = sys.argv[1]
+s = open(p).read()
+old = """    if (len > channel->local_window) {
+        SSH_LOG(SSH_LOG_RARE,
+                "Data packet too big for our window(%" PRIu32 " vs %" PRIu32 ")",
+                len,
+                channel->local_window);"""
+new = """    /* REPRO HOOK: pretend our local window diverged below this packet, for the
+     * first DROP_FIRST packets of at least DROP_MIN_LEN bytes. The discard
+     * below is then real -- the payload is freed and never delivered.
+     * DROP_WINDOW is the fake window (0 = nothing fits, the default). */
+    uint32_t effective_window = channel->local_window;
+    static int clamp_fix = -1;
+    {
+        static int drop_left = -1;
+        static uint32_t drop_min_len = 0, drop_window = 0;
+        if (drop_left == -1) {
+            const char *df = getenv("LIBSSH_REPRO_DROP_FIRST");
+            const char *ml = getenv("LIBSSH_REPRO_DROP_MIN_LEN");
+            const char *dw = getenv("LIBSSH_REPRO_DROP_WINDOW");
+            drop_left = (df && *df) ? (int)strtol(df, NULL, 10) : 0;
+            drop_min_len = (ml && *ml) ? (uint32_t)strtoul(ml, NULL, 10) : 0;
+            drop_window = (dw && *dw) ? (uint32_t)strtoul(dw, NULL, 10) : 0;
+        }
+        if (clamp_fix == -1)
+            clamp_fix = getenv("LIBSSH_CLAMP_FIX") != NULL;
+        if (drop_left > 0 && len >= drop_min_len) {
+            drop_left--;
+            effective_window = drop_window;
+        }
+    }
+    /* CANDIDATE FIX (LIBSSH_CLAMP_FIX=1): RFC 4254 5.2 permits ignoring "all
+     * extra data sent after the allowed window is empty" -- the EXTRA data.
+     * Deliver what fits, drop only the excess, and record no error, because
+     * this is sanctioned behaviour rather than a fault. Clamping len here makes
+     * the stock test below false, so we fall through to the normal bufferize
+     * path. Stock libssh frees the whole payload and sets SSH_FATAL instead. */
+    if (len > effective_window && clamp_fix) {
+        SSH_LOG(SSH_LOG_RARE,
+                "Data packet exceeds our window (%" PRIu32 " vs %" PRIu32
+                "), delivering what fits and ignoring the rest",
+                len,
+                effective_window);
+        len = effective_window;
+        if (len == 0) {
+            SSH_STRING_FREE(str);
+            return SSH_PACKET_USED;
+        }
+    }
+    if (len > effective_window) {
+        SSH_LOG(SSH_LOG_RARE,
+                "Data packet too big for our window(%" PRIu32 " vs %" PRIu32 ")",
+                len,
+                effective_window);"""
+if old not in s:
+    sys.exit("channels.c does not match the expected source; hook not applied")
+open(p, "w").write(s.replace(old, new, 1))
+print("  hook applied")
+PY
+[ $? -eq 0 ] || die "could not patch channels.c"
+
+# ---------------------------------------------------------------- 3. build wiring
+say "Pointing deps/libssh at the local copy"
+python3 - <<'PY'
+import re
+p = 'deps/libssh/build.zig.zon'
+s = open(p).read()
+s = re.sub(r'\.libssh_upstream = \.\{.*?\},',
+           '.libssh_upstream = .{\n            .path = "libssh-local",\n        },',
+           s, count=1, flags=re.S)
+open(p, 'w').write(s)
+
+# Older libssh checkouts carry src/alloc.c, which some wrappers do not list;
+# without it the link fails on libssh_calloc and friends.
+import os
+if os.path.exists('deps/libssh/libssh-local/src/alloc.c'):
+    b = open('deps/libssh/build.zig').read()
+    if '"src/alloc.c"' not in b:
+        b = b.replace('        "src/agent.c",', '        "src/alloc.c",\n        "src/agent.c",', 1)
+        open('deps/libssh/build.zig', 'w').write(b)
+        print("  added src/alloc.c to the wrapper source list")
+PY
+[ $? -eq 0 ] || die "could not point deps/libssh at the local copy"
+
+# ---------------------------------------------------------------- 4. run
+# The storm server writes its hello in 1024 B chunks; its client writes a 174 B
+# hello. A 1000 B threshold therefore targets only the server->client stream.
+# LIBSSH_REPRO_DROP_WINDOW is the fake window for the chosen packet: 0 means
+# nothing fits, 500 means a 1024 B packet overruns by 524 -- which is where the
+# clamp fix differs from the stock discard.
+export LIBSSH_REPRO_DROP_FIRST=1
+export LIBSSH_REPRO_DROP_MIN_LEN=1000
+export LIBSSH_REPRO_DROP_WINDOW="${LIBSSH_REPRO_DROP_WINDOW:-0}"
+export ACTON_SSH_STORM_NUM=1
+
+buildlog=$("$ACTON" build 2>&1)
+if [ $? -ne 0 ]; then
+    echo "$buildlog" | grep -iE "error" | head -5
+    die "build failed -- results would be meaningless"
+fi
+
+run_mode() {
+    local label="$1"
+    say "$label -- $REPEATS runs"
+    local corrupt=0 blocked=0 other=0 sample=""
+    for _ in $(seq 1 "$REPEATS"); do
+        out=$("$ACTON" test --no-cache --show-log --module test_ssh_hello_storm \
+                  --max-time 60000 --min-iter 1 --max-iter 1 2>&1)
+        if grep -q "corrupt hello" <<<"$out"; then
+            corrupt=$((corrupt+1))
+            [ -z "$sample" ] && sample=$(grep -m1 "corrupt hello" <<<"$out")
+        elif grep -qE "Exception|errored" <<<"$out"; then
+            blocked=$((blocked+1))
+        else
+            other=$((other+1))
+        fi
+    done
+    printf '  corrupt data reached the application : %d/%d\n' "$corrupt" "$REPEATS"
+    printf '  session failed first (no bad data)   : %d/%d\n' "$blocked" "$REPEATS"
+    [ "$other" -gt 0 ] && printf '  test passed (drop missed the stream) : %d/%d\n' "$other" "$REPEATS"
+    [ -n "$sample" ] && printf '  sample:%s\n' "${sample#*Exception:}"
+}
+
+echo
+echo "  fake window for the dropped packet: $LIBSSH_REPRO_DROP_WINDOW bytes (packet is 1024)"
+
+unset LIBSSH_CLAMP_FIX
+run_mode "STOCK libssh (drops the whole packet, sets SSH_FATAL)"
+
+export LIBSSH_CLAMP_FIX=1
+run_mode "CLAMP PATCH (delivers what fits, records no error)"
+
+say "Done"


### PR DESCRIPTION
libssh's channel_rcv_data frees a whole CHANNEL_DATA payload and returns SSH_PACKET_USED when it exceeds the channel's local window. The session keeps running minus those bytes, so the application sees a stream missing its head, and ssh_event_dopoll cannot report it.

session_event_poll now compares the session error code across the poll and fails the session if a fatal error appeared during it. The snapshot avoids tripping on a stale error.

this narrows the race rather than closing it: dopoll runs the data callbacks inline. Measured 6 of 12 and 7 of 11 blocked, versus none unguarded.

added storm regression test and a harness that forces a real discard

related to https://github.com/actonlang/acton-ssh/issues/7

this does not fully fix the issue, it's just a minor improvement

you can see in src/test_ssh_hello_storm.sh that the libssh is in one case run patched. which might be the proper fix. but it is questionable if upstream would allow/merge that change.
More details regarding the libssh behavior that causes this issue:

What RFC 4254 says:

> Section 5.2, *Data Transfer*, verbatim:
> 
> > The window size specifies how many bytes the other party can send before it
> > must wait for the window to be adjusted.
> 
> > The maximum amount of data allowed is determined by the maximum packet size
> > for the channel, and the current window size, whichever is smaller.
> 
> > Both parties MAY ignore all extra data sent after the allowed window is empty.
> 
> So a **sender** that exceeds the advertised window violates the second sentence.
> A **receiver** that ignores the excess is explicitly permitted by the third.
> Ignoring is sanctioned; terminating the connection is also allowed but is
> harsher than the RFC contemplates and breaks interop with a peer that overshoots
> slightly.

what the libssh patch does and does not fix:

It does **not** stop data loss. When this branch is reached, bytes beyond the
window are gone either way — the clamp only delivers the portion that was within
the window instead of nothing. The wins are that a partially-overrunning peer no
longer costs a whole packet, and that the session's error state is no longer incorrect.

Note the interaction with the mitigation in `session_event_poll`: that check
exists solely because the discard is silent. Clamping removes the bogus
`SSH_FATAL`, so with this patch the guard no longer fires for this branch — and
any residual loss becomes silent again. Keep the guard for the `CLOSED_REMOTE`
branch and for any future handler that records a fatal without acting on it, but
do not expect the two changes to compose into a guarantee.

The underlying question is still open: **why** `len > local_window` occurs in
the field. Whether the peer overshoots the advertised window or libssh's own
accounting drifts decides whether this patch is the remedy or merely makes a
peer bug less damaging. `ACTON_SSH_LIBSSH_LOG=warn` prints
`Data packet too big for our window(N vs M)`; comparing `M` against what the
peer should have believed the window to be identifies which side drifted.
